### PR TITLE
Update ItemStrings_zh-CN.xaml

### DIFF
--- a/Resource/Localization/ItemStrings_zh-CN.xaml
+++ b/Resource/Localization/ItemStrings_zh-CN.xaml
@@ -9,113 +9,113 @@
 
     <!--Blade of the Ruined King-->
     <s:String x:Key="BOTRK" xml:space="preserve">破败王者之刃</s:String>
-    <s:String x:Key="BOTRK1" xml:space="preserve">&#10;携带者也是一名剑士</s:String>
+    <s:String x:Key="BOTRK1" xml:space="preserve">&#10;携带者也是剑士</s:String>
     <!--Darkin-->
     <s:String x:Key="Darkin" xml:space="preserve">暗裔</s:String>
-    <s:String x:Key="Darkin1" xml:space="preserve">&#10;携带者也是一名恶魔</s:String>
+    <s:String x:Key="Darkin1" xml:space="preserve">&#10;装备者也视为恶魔</s:String>
     <!--Force of Nature-->
     <s:String x:Key="ForceOfNature" xml:space="preserve">自然之力</s:String>
-    <s:String x:Key="ForceOfNature1" xml:space="preserve">&#10;上限人口+1</s:String>
+    <s:String x:Key="ForceOfNature1" xml:space="preserve">&#10;可上阵人数+1</s:String>
     <!--Frozen Mallet-->
     <s:String x:Key="FrozenMallet" xml:space="preserve">冰霜之锤</s:String>
-    <s:String x:Key="FrozenMallet1" xml:space="preserve">&#10;携带者也是一名极地生物</s:String>
+    <s:String x:Key="FrozenMallet1" xml:space="preserve">&#10;装备者也视为极地</s:String>
     <!--Knight's Vow-->
     <s:String x:Key="KnightsVow" xml:space="preserve">骑士之誓</s:String>
-    <s:String x:Key="KnightsVow1" xml:space="preserve">&#10;携带者也是一名骑士</s:String>
+    <s:String x:Key="KnightsVow1" xml:space="preserve">&#10;携带者也是骑士单位</s:String>
     <!--Runaan's Hurricane-->
     <s:String x:Key="RunaansHurricane" xml:space="preserve">卢安娜的飓风</s:String>
-    <s:String x:Key="RunaansHurricane1" xml:space="preserve">&#10;攻击可选取1个额外敌人,造成25%伤害并施加攻击特效</s:String>
+    <s:String x:Key="RunaansHurricane1" xml:space="preserve">&#10;普攻对额外1个目标造成伤害，额外攻击造成75%的伤害，附带普攻特效</s:String>
     <!--Youmuu's Ghostblade-->
     <s:String x:Key="YoumuusGhostblade" xml:space="preserve">幽梦之灵</s:String>
-    <s:String x:Key="YoumuusGhostblade1" xml:space="preserve">&#10;携带者也是一名刺客</s:String>
+    <s:String x:Key="YoumuusGhostblade1" xml:space="preserve">&#10;携带者也是刺客单位</s:String>
     <!--Yuumi-->
     <s:String x:Key="Yuumi" xml:space="preserve">悠米</s:String>
-    <s:String x:Key="Yuumi1" xml:space="preserve">&#10;携带者也是一名法师</s:String>
+    <s:String x:Key="Yuumi1" xml:space="preserve">&#10;携带者也是法师单位</s:String>
 
     <!--Bloodthirster-->
     <s:String x:Key="Bloodthirster" xml:space="preserve">饮血剑</s:String>
-    <s:String x:Key="Bloodthirster1" xml:space="preserve">&#10;+50%普通攻击吸血</s:String>
+    <s:String x:Key="Bloodthirster1" xml:space="preserve">&#10;普攻攻击附带40%吸血</s:String>
     <!--Cursed Blade-->
     <s:String x:Key="CursedBlade" xml:space="preserve">诅咒之刃</s:String>
-    <s:String x:Key="CursedBlade1" xml:space="preserve">&#10;普通攻击有20%概率使敌人缩小1星</s:String>
+    <s:String x:Key="CursedBlade1" xml:space="preserve">&#10;普通攻击有20%使敌人缩小1星</s:String>
     <!--Dragon's Claw-->
     <s:String x:Key="DragonsClaw" xml:space="preserve">巨龙之爪</s:String>
-    <s:String x:Key="DragonClaw1" xml:space="preserve">&#10;获得83%对魔法伤害的抗性</s:String>
+    <s:String x:Key="DragonClaw1" xml:space="preserve">&#10;装备者获得83%魔法抗性</s:String>
     <!--Frozen Heart-->
     <s:String x:Key="FrozenHeart" xml:space="preserve">冰霜之心</s:String>
-    <s:String x:Key="FrozenHeart1" xml:space="preserve">&#10;邻近格子的敌人们失去20%攻击速度</s:String>
+    <s:String x:Key="FrozenHeart1" xml:space="preserve">&#10;邻近格子的敌人降低20%攻击速度</s:String>
     <!--Guardian Angel-->
     <s:String x:Key="GuardianAngel" xml:space="preserve">守护天使</s:String>
-    <s:String x:Key="GuardianAngel1" xml:space="preserve">&#10;携带者会复活并具有1000生命值，复活时间2秒</s:String>
+    <s:String x:Key="GuardianAngel1" xml:space="preserve">&#10;阵亡2秒后复活,复活后恢复500生命值</s:String>
     <!--Guinsoo's Rageblade-->
     <s:String x:Key="GuinsoosRageblade" xml:space="preserve">鬼索的狂暴之刃</s:String>
-    <s:String x:Key="GuinsoosRageblade1" xml:space="preserve">&#10;攻击提供4%攻击速度。可无限叠加</s:String>
+    <s:String x:Key="GuinsoosRageblade1" xml:space="preserve">&#10;每次攻击增加5%攻击速度，无上限</s:String>
     <!--Hextech Gunblade-->
     <s:String x:Key="HextechGunblade" xml:space="preserve">海克斯科技枪刃</s:String>
     <s:String x:Key="HextechGunblade1" xml:space="preserve">&#10;+25%全能吸血</s:String>
     <!--Hush-->
     <s:String x:Key="Hush" xml:space="preserve">肃静</s:String>
-    <s:String x:Key="Hush1" xml:space="preserve">&#10;攻击有50%几率造成沉默效果，持续3秒</s:String>
+    <s:String x:Key="Hush1" xml:space="preserve">&#10;普通攻击有50%对敌人造成3秒沉默</s:String>
     <!--Infinity Edge-->
     <s:String x:Key="InfinityEdge" xml:space="preserve">无尽之刃</s:String>
-    <s:String x:Key="InfinityEdge1" xml:space="preserve">&#10;暴击造成+150%伤害</s:String>
+    <s:String x:Key="InfinityEdge1" xml:space="preserve">&#10;+150%暴击伤害</s:String>
     <!--Ionic Spark-->
     <s:String x:Key="IonicSpark" xml:space="preserve">离子火花</s:String>
-    <s:String x:Key="IonicSpark1" xml:space="preserve">&#10;敌人在每次施放技能时,都会承受150真实伤害</s:String>
+    <s:String x:Key="IonicSpark1" xml:space="preserve">&#10;每当敌人使用技能，他们受到150点真实伤害</s:String>
     <!--Locket of the Iron Solari-->
     <s:String x:Key="LocketSolari" xml:space="preserve">钢铁烈阳之匣</s:String>
-    <s:String x:Key="LocketSolari1" xml:space="preserve">&#10;战斗开始时，为持有者及其左右两格内的英雄提供250点护盾，持续4秒</s:String>
+    <s:String x:Key="LocketSolari1" xml:space="preserve">&#10;战斗开始前，为持有者及其左右两格内的英雄施加一个持续7秒的300点护盾。</s:String>
     <!--Luden's Echo-->
     <s:String x:Key="LudensEcho" xml:space="preserve">卢登的回声</s:String>
-    <s:String x:Key="LudensEcho1" xml:space="preserve">&#10;技能在命中时造成200溅射伤害</s:String>
+    <s:String x:Key="LudensEcho1" xml:space="preserve">&#10;技能对命中目标造成200点溅射伤害</s:String>
     <!--Morellonomicon-->
     <s:String x:Key="Morello" xml:space="preserve">莫雷洛秘典</s:String>
-    <s:String x:Key="Morello1" xml:space="preserve">&#10;技能造成燃烧伤害,每秒伤害值相当于敌人5%的最大生命值</s:String>
+    <s:String x:Key="Morello1" xml:space="preserve">&#10;技能造成灼烧伤害，伤害为敌人最大生命值的20%，并造成禁止治疗效果</s:String>
     <!--Phantom Dancer-->
     <s:String x:Key="PhantomDancer" xml:space="preserve">幻影之舞</s:String>
-    <s:String x:Key="PhantomDancer1" xml:space="preserve">&#10;携带者会闪避所有暴击</s:String>
+    <s:String x:Key="PhantomDancer1" xml:space="preserve">&#10;装备者闪避所有暴击攻击（包含来自技能的暴击伤害）</s:String>
     <!--Rabadon's Deathcap-->
     <s:String x:Key="RabadonsDeathcap" xml:space="preserve">灭世者的死亡之帽</s:String>
-    <s:String x:Key="RabadonsDeathcap1" xml:space="preserve">&#10;+50%法术伤害</s:String>
+    <s:String x:Key="RabadonsDeathcap1" xml:space="preserve">&#10;增加50%技能伤害</s:String>
     <!--Rapid Firecannon-->
     <s:String x:Key="RapidFirecannon" xml:space="preserve">疾射火炮</s:String>
-    <s:String x:Key="RapidFirecannon1" xml:space="preserve">&#10;携带者的攻击不会被闪避,攻击距离翻倍</s:String>
+    <s:String x:Key="RapidFirecannon1" xml:space="preserve">&#10;携带者的攻击不会被闪避，攻击距离加倍</s:String>
     <!--Red Buff-->
-    <s:String x:Key="RedBuff" xml:space="preserve">红色增益</s:String>
-    <s:String x:Key="RedBuff1" xml:space="preserve">&#10;攻击造成2.5%燃烧伤害，并阻止生命回复</s:String>
+    <s:String x:Key="RedBuff" xml:space="preserve">蜥蜴长老之赐</s:String>
+    <s:String x:Key="RedBuff1" xml:space="preserve">&#10;攻击在5秒内造成目标13%最大生命值的灼烧伤害，并且造成禁止治疗效果</s:String>
     <!--Redemption-->
     <s:String x:Key="Redemption" xml:space="preserve">救赎</s:String>
-    <s:String x:Key="Redemption1" xml:space="preserve">&#10;生命值低于25%时，治疗附近友军1000生命值</s:String>
+    <s:String x:Key="Redemption1" xml:space="preserve">&#10;在生命值降低到25%时，治疗附近所有友军1200点生命值</s:String>
     <!--Seraph's Embrace-->
     <s:String x:Key="SeraphsEmbrace" xml:space="preserve">炽天使之拥</s:String>
-    <s:String x:Key="SeraphsEmbrace1" xml:space="preserve">&#10;在每有一个技能被施放时回复20法力</s:String>
+    <s:String x:Key="SeraphsEmbrace1" xml:space="preserve">&#10;佩戴者每次施放技能时，回复20点法力值</s:String>
     <!--Spear of Shojin-->
     <s:String x:Key="SpearofShojin" xml:space="preserve">朔极之矛</s:String>
-    <s:String x:Key="SpearofShojin1" xml:space="preserve">&#10;在第一次技能施放后,每次攻击回复自身15%最大法力值</s:String>
+    <s:String x:Key="SpearofShojin1" xml:space="preserve">&#10;在使用技能后，携带者的每次攻击回复15%最大法力值</s:String>
     <!--Spear of Shojin-->
     <s:String x:Key="StatikkShiv" xml:space="preserve">斯塔提克电刃</s:String>
-    <s:String x:Key="StatikkShiv1" xml:space="preserve">&#10;携带者的第三次攻击会对额外3个目标造成90点魔法伤害</s:String>
+    <s:String x:Key="StatikkShiv1" xml:space="preserve">&#10;每3次攻击，造成90点溅射魔法伤害。总会命中3个额外的目标</s:String>
     <!--Sword Breaker-->
     <s:String x:Key="SwordBreaker" xml:space="preserve">折剑者</s:String>
-    <s:String x:Key="SwordBreaker1" xml:space="preserve">&#10;攻击有25%几率造成缴械效果</s:String>
+    <s:String x:Key="SwordBreaker1" xml:space="preserve">&#10;普通攻击有33%对敌人造成缴械3秒</s:String>
     <!--Sword of the Divine-->
     <s:String x:Key="SwordDivine" xml:space="preserve">神圣之剑</s:String>
-    <s:String x:Key="SwordDivine1" xml:space="preserve">&#10;携带者每秒都有5%几率获得100%暴击几率</s:String>
+    <s:String x:Key="SwordDivine1" xml:space="preserve">&#10;每秒钟佩戴者有7%的几率获得100%的暴击</s:String>
     <!--Thornmail-->
     <s:String x:Key="Thornmail" xml:space="preserve">荆棘之甲</s:String>
-    <s:String x:Key="Thornmail1" xml:space="preserve">&#10;反弹所减免伤害的100%的魔法伤害</s:String>
+    <s:String x:Key="Thornmail1" xml:space="preserve">&#10;反弹所受到伤害的100%的魔法伤害</s:String>
     <!--Titanic Hydra-->
     <s:String x:Key="TitanicHydra" xml:space="preserve">巨型九头蛇</s:String>
-    <s:String x:Key="TitanicHydra1" xml:space="preserve">&#10;攻击造成基于携带者10%最大生命值的溅射伤害</s:String>
+    <s:String x:Key="TitanicHydra1" xml:space="preserve">&#10;攻击对敌人造成携带者10%最大生命值的溅射伤害</s:String>
     <!--Warmog's Armor-->
     <s:String x:Key="WarmogsArmor" xml:space="preserve">狂徒铠甲</s:String>
-    <s:String x:Key="WarmogsArmor1" xml:space="preserve">&#10;携带者每秒回复6%已损失生命值</s:String>
+    <s:String x:Key="WarmogsArmor1" xml:space="preserve">&#10;每秒恢复6%已损失生命值</s:String>
     <!--Zeke's Herald-->
     <s:String x:Key="ZekesHerald" xml:space="preserve">基克的先驱</s:String>
-    <s:String x:Key="ZekesHerald1" xml:space="preserve">&#10;战斗开始时，为持有者及其左右两格内的英雄提供15%攻速</s:String>
+    <s:String x:Key="ZekesHerald1" xml:space="preserve">&#10;为持有者左右两格内的英雄提供15%攻速</s:String>
     <!--Zephyr-->
     <s:String x:Key="Zephyr" xml:space="preserve">灵风</s:String>
-    <s:String x:Key="Zephyr1" xml:space="preserve">&#10;战斗开始时，放逐一名敌人5秒</s:String>
+    <s:String x:Key="Zephyr1" xml:space="preserve">&#10;战斗开始时，放逐1个敌人持续6秒</s:String>
 
     <!--/////////////////-->
     <!--ClassOrigins Descriptions-->


### PR DESCRIPTION
中国LOL云顶之弈版本暂时为9.18（2019.9.15），所有装备合成翻译来自于：https://lol.qq.com/act/a20190702loltftwf/index.html#tab1
9.19暂未更新。但是不影响插件版本更新9.19的使用。
就是不知道我源文件用的对么……应该是对的。。不对就。。这条能删了吗。。
（英语来自翻译软件~嘻嘻嘻）
English comes from translation software(#^.^#)
China LOL genting ground of version 9.18 (2019.9.15) temporarily, all equipped with synthetic translation comes from: https://lol.qq.com/act/a20190702loltftwf/index.html#tab1
9.19 has not been updated.This does not affect the use of plug-in version update 9.19.
Just don't know if I used the source file right... Should be right. No. Can I delete this one?